### PR TITLE
remove processor that no longer exists

### DIFF
--- a/solutions-geoevent/pom.xml
+++ b/solutions-geoevent/pom.xml
@@ -23,7 +23,6 @@
 		<module>processors/buffer-processor</module>
 		<module>processors/ellipse-processor</module>
 		<module>processors/eventVolumeControl-processor</module>
-		<module>processors/fieldgrouper-processor</module>
 		<module>processors/query-report-processor</module>
 		<module>processors/rangefan-processor</module>
 		<module>processors/symbol-lookup-processor</module>


### PR DESCRIPTION
This causes mvn to fail.