### PR TITLE
CoT Adapter: versioning improvements

### DIFF
--- a/solutions-geoevent/adapters/cot-adapter/pom.xml
+++ b/solutions-geoevent/adapters/cot-adapter/pom.xml
@@ -12,7 +12,7 @@
 	
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.esri.geoevent.solutions.adapter.cot</groupId>
-	<version>10.5.0</version>
+	<version>${project.version}</version>
 	<artifactId>cot-adapter</artifactId>
 	<name>Esri :: AGES :: Solutions :: Adapter :: CoT</name>
 	<packaging>bundle</packaging>
@@ -22,6 +22,7 @@
 		<maven.bundle.plugin.version>2.3.6</maven.bundle.plugin.version>
 		<junit.version>4.8.1</junit.version>
 		<jackson.version>1.9.5</jackson.version>
+                <project.version>10.5.0</project.version>
 	</properties>
 	<repositories>
 		<repository>
@@ -40,7 +41,8 @@
 		<dependency>
 			<groupId>com.esri.geoevent.sdk</groupId>
 			<artifactId>geoevent-sdk</artifactId>
-			<version>10.5.0</version>
+			<version>${project.version}</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>
@@ -64,11 +66,6 @@
 			<artifactId>org.osgi.core</artifactId>
 			<version>1.0.0</version>
 			<scope>provided</scope>
-		</dependency>
-		<dependency>
-   			<groupId>com.esri.geometry</groupId>
-   			<artifactId>geometry-api</artifactId>
-   			<version>10.5.0</version>
 		</dependency>
 	</dependencies>
 

--- a/solutions-geoevent/adapters/cot-adapter/pom.xml
+++ b/solutions-geoevent/adapters/cot-adapter/pom.xml
@@ -22,7 +22,7 @@
 		<maven.bundle.plugin.version>2.3.6</maven.bundle.plugin.version>
 		<junit.version>4.8.1</junit.version>
 		<jackson.version>1.9.5</jackson.version>
-                <project.version>10.5.0</project.version>
+		<project.version>10.5.0</project.version>
 	</properties>
 	<repositories>
 		<repository>

--- a/solutions-geoevent/adapters/cot-adapter/src/main/resources/input-connector-definition.xml
+++ b/solutions-geoevent/adapters/cot-adapter/src/main/resources/input-connector-definition.xml
@@ -2,9 +2,9 @@
 	type="inbound">
 	<description>Receive Cursor on Target messages</description>
 	<defaultName>cot-in</defaultName>
-	<transport uri="com.esri.ges.transport.inbound/HTTP/10.3.1" />
+	<transport uri="com.esri.ges.transport.inbound/HTTP/10.5.0" />
 	<adapter
-		uri="com.esri.geoevent.solutions.adapter.cot.inbound/CursorOnTargetIn/10.3.1" />
+		uri="com.esri.geoevent.solutions.adapter.cot.inbound/CursorOnTargetIn/10.5.0" />
 	<properties>
 		<shown>
 			<property name="XSD_Path" label="XSD_Path" source="adapter"


### PR DESCRIPTION
- Updated `10.3.1` to `10.5.0 ` in connector definition
- Using a `project.version` property instead of hardcoded `10.5.0` in
pom.xml
- Removed unneccesary and erroneous geometry-api dependency