### PR TITLE
Cache aware processor add nvl function

### DIFF
--- a/solutions-geoevent/processors/cache-aware-fieldcalculator/cache-aware-fieldcalculator-processor/pom.xml
+++ b/solutions-geoevent/processors/cache-aware-fieldcalculator/cache-aware-fieldcalculator-processor/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>com.esri.geoevent.parent</groupId>
 		<artifactId>cache-aware-fieldcalculator</artifactId>
-		<version>10.3.0</version>
+		<version>10.5.0</version>
 	</parent>
 	<packaging>bundle</packaging>
 	<groupId>com.esri.geoevent.processor</groupId>

--- a/solutions-geoevent/processors/cache-aware-fieldcalculator/cache-aware-fieldcalculator-processor/src/main/java/com/esri/geoevent/processor/cacheawarefieldcalculator/CacheAwareFieldCalculatorDefinition.java
+++ b/solutions-geoevent/processors/cache-aware-fieldcalculator/cache-aware-fieldcalculator-processor/src/main/java/com/esri/geoevent/processor/cacheawarefieldcalculator/CacheAwareFieldCalculatorDefinition.java
@@ -60,7 +60,7 @@ public class CacheAwareFieldCalculatorDefinition extends GeoEventProcessorDefini
   @Override
   public String getVersion()
   {
-  	return "10.3.0";
+  	return "10.5.0";
   }
   
   @Override

--- a/solutions-geoevent/processors/cache-aware-fieldcalculator/cache-aware-fieldcalculator-processor/src/main/java/com/esri/geoevent/processor/cacheawarefieldcalculator/expression/ExpressionBuilder.java
+++ b/solutions-geoevent/processors/cache-aware-fieldcalculator/cache-aware-fieldcalculator-processor/src/main/java/com/esri/geoevent/processor/cacheawarefieldcalculator/expression/ExpressionBuilder.java
@@ -1458,7 +1458,16 @@ public class ExpressionBuilder
           return (args != null && args.length == 2) ? String.valueOf(args[0]).contains(String.valueOf(args[1])) : null;
         }
       });
-      
+
+      functions.put("nvl", new Function("nvl", 2)
+      {
+        @Override
+        public Object applyFunction(Object... args)
+        {
+          return (args != null && args.length == 2) ? (args[0] != null ? args[0] : args[1]) : null;
+        }
+      });
+			
       functions.put("replaceFirst", new Function("replaceFirst", 3)
       {
         @Override

--- a/solutions-geoevent/processors/cache-aware-fieldcalculator/pom.xml
+++ b/solutions-geoevent/processors/cache-aware-fieldcalculator/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>com.esri.geoevent.parent</groupId>
 	<artifactId>cache-aware-fieldcalculator</artifactId>
-	<version>10.3.0</version>
+	<version>10.5.0</version>
 	<packaging>pom</packaging>
 
 	<name>Esri :: GeoEvent :: Cache-Aware Field Calculator</name>
@@ -25,7 +25,7 @@
 		<dependency>
 			<groupId>com.esri.geoevent.sdk</groupId>
 			<artifactId>geoevent-sdk</artifactId>
-			<version>10.3.0</version>
+			<version>10.5.0</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
When there is no previous GeoEvent in the cache, the cachedGeoEvent(fieldName) function returns null, but this can lead to exceptions elsewhere in the expression where the value is referenced from operators or functions that are not null-safe.

To work around this, a new function was added, nvl, simply taking two arguments and returning the first argument if non-null, and otherwise returning the second argument.

Also, version numbers and dependencies were updated to 10.5.0.