### PR TITLE
Update bundle plugin and Java source version for forward compatibility

### DIFF
--- a/solutions-geoevent/processors/cache-aware-fieldcalculator/pom.xml
+++ b/solutions-geoevent/processors/cache-aware-fieldcalculator/pom.xml
@@ -13,7 +13,7 @@
 	<properties>
 		<contact.address>geoevent@esri.com</contact.address>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.bundle.plugin.version>2.3.6</maven.bundle.plugin.version>
+		<maven.bundle.plugin.version>5.1.1</maven.bundle.plugin.version>
 		<junit.version>4.8.1</junit.version>
 	</properties>
 
@@ -25,7 +25,7 @@
 		<dependency>
 			<groupId>com.esri.geoevent.sdk</groupId>
 			<artifactId>geoevent-sdk</artifactId>
-			<version>10.5.0</version>
+			<version>${project.version}</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
@@ -50,8 +50,8 @@
 					<artifactId>maven-compiler-plugin</artifactId>
 					<version>2.5.1</version>
 					<configuration>
-						<source>1.7</source>
-						<target>1.7</target>
+						<source>1.8</source>
+						<target>1.8</target>
 					</configuration>
 				</plugin>
 			</plugins>


### PR DESCRIPTION
Updates to make Cache-Aware Field Processor forward compatible with later versions of GeoEvent Server. It was using a very old version of the Maven Bundle Plugin which contained bugs, such that the artifacts would not deploy reliably in later versions of GeoEvent Server. Updating to current resolved it. Also updated Java source / target version from 1.7 to 1.8 (used at least since GeoEvent Server 10.4), and used ${project.version} for GeoEvent SDK version as already done in the legacy pom. Project version remains at 10.5.0 so that backward compatibility is preserved. Tested in 10.7.1.